### PR TITLE
Create a wrapper for the channels

### DIFF
--- a/lib/archivist.rb
+++ b/lib/archivist.rb
@@ -4,9 +4,10 @@ require "securerandom"
 require "slack-ruby-client"
 
 require "archivist/config"
-require "archivist/client"
 
 require "archivist/archive_channels"
+require "archivist/channel"
+require "archivist/client"
 require "archivist/rule"
 
 module Archivist

--- a/lib/archivist/channel.rb
+++ b/lib/archivist/channel.rb
@@ -1,0 +1,183 @@
+module Archivist
+  class Channel
+    extend Memoist
+
+    IGNORED_MESSAGE_TYPES = %w[
+      bot_message
+      channel_join
+      channel_leave
+      message_deleted
+    ].freeze
+
+    DEFAULT_ARCHIVABLE_DAYS = 30
+    # This is one day less than the cycle length to allow for fuzziness in
+    # run times.
+    DAYS_AFTER_WARNING_BEFORE_ARCHIVING = 6
+
+    WARNING_BLOCK_ID_PREFIX = "archivist-warn"
+
+    attr_reader :channel, :log
+
+    def initialize(channel)
+      @channel = channel
+      @log = Logger.new(STDOUT)
+    end
+
+    def id
+      channel.id
+    end
+    memoize :id
+
+    def name
+      channel.name
+    end
+    memoize :name
+
+    def member?
+      channel.is_member || false
+    end
+    memoize :member?
+
+    def general?
+      channel.is_general || false
+    end
+    memoize :general?
+
+    def report_target?
+      id == Config.report_channel_id
+    end
+    memoize :report_target?
+
+    def shared?
+      channel.is_shared || channel.pending_shared&.any? || false
+    end
+    memoize :shared?
+
+    def monitored?
+      !not_monitored?
+    end
+    memoize :monitored?
+
+    def not_monitored?
+      if Config.use_default_rules
+        never_monitored? || matching_rule&.skip || false
+      else
+        never_monitored? || matching_rule.nil? || matching_rule.skip || false
+      end
+    end
+    memoize :not_monitored?
+
+    def warnable?
+      stale? && not_warned?
+    end
+    memoize :warnable?
+
+    def archivable?
+      stale? && warned?(min_days_ago: DAYS_AFTER_WARNING_BEFORE_ARCHIVING)
+    end
+    memoize :archivable?
+
+    private
+
+    def matching_rule
+      Config.rules.detect { |rule| rule.match?(channel) }
+    end
+    memoize :matching_rule
+
+    def never_monitored?
+      general? || shared? || labeled_as_no_archive? || false
+    end
+    memoize :never_monitored?
+
+    def labeled_as_no_archive?
+      Config.no_archive_label.present? &&
+        channel.purpose&.value&.include?(Config.no_archive_label) ||
+        channel.topic&.value&.include?(Config.no_archive_label) ||
+        false
+    end
+    memoize :labeled_as_no_archive?
+
+    def stale?
+      rule = Config.rules.detect { |rule| rule.match?(channel) }
+
+      has_no_recent_real_messages?(max_days_ago: rule&.days)
+    end
+    memoize :stale?
+
+    def warned?(min_days_ago: nil)
+      rule = Config.rules.detect { |rule| rule.match?(channel) }
+
+      has_warning_message?(
+        min_days_ago: min_days_ago,
+        # We ignore warnings outside of the stale range so that if something
+        # went wrong, we'd warn again eventually.
+        max_days_ago: rule&.days
+      )
+    end
+
+    def not_warned?
+      !warned?
+    end
+
+    def has_recent_real_messages?(max_days_ago: nil)
+      log.info("Checking ##{channel.name} for real messages...")
+
+      Client.last_messages_in(
+        channel,
+        max_days_ago: max_days_ago || DEFAULT_ARCHIVABLE_DAYS
+      ) do |response|
+        real_messages = response.messages.reject { |message|
+          message.hidden ||
+            message.bot_id ||
+            IGNORED_MESSAGE_TYPES.include?(message.subtype)
+        }
+
+        if real_messages.any?
+          log.info("   ...found real messages")
+
+          return true
+        end
+      end
+
+      log.info("   ...no real messages found")
+
+      false
+    end
+
+    def has_no_recent_real_messages?(max_days_ago: nil)
+      !has_recent_real_messages?(max_days_ago: max_days_ago)
+    end
+
+    def has_warning_message?(min_days_ago: nil, max_days_ago: nil)
+      log.info("Checking ##{channel.name} for recent warning messages...")
+
+      Client.last_messages_in(
+        channel,
+        # We run in small batches as we run this on channels that don't have
+        # recent activity, so we expect the warning message to be very near
+        # the end.
+        limit: 5,
+        min_days_ago: min_days_ago,
+        max_days_ago: max_days_ago
+      ) do |response|
+        warning_message = response.messages.detect { |message|
+          (message.subtype == "bot_message" || message.bot_id) &&
+            message.blocks &&
+            message.blocks[0].block_id.start_with?(WARNING_BLOCK_ID_PREFIX)
+        }
+
+        if warning_message
+          message_sent_at = Time.new(warning_message.ts)
+
+          log.info("   ...found warning message sent at #{message_sent_at}")
+
+          return true if message_sent_at >= Date.today - DEFAULT_ARCHIVABLE_DAYS
+        end
+      end
+
+      log.info("   ...no recent warning messages found")
+
+      false
+    end
+  end
+end

--- a/lib/archivist/client.rb
+++ b/lib/archivist/client.rb
@@ -18,7 +18,11 @@ module Archivist
           # Client configuration
           sleep_interval: 2
         ) do |response|
-          channels.concat(response.channels)
+          new_channels = response.channels.map { |channel|
+            Channel.new(channel)
+          }
+
+          channels.concat(new_channels)
         end
 
         channels

--- a/spec/archivist/channel_spec.rb
+++ b/spec/archivist/channel_spec.rb
@@ -1,0 +1,490 @@
+describe Archivist::Channel do
+  let(:no_archive_label) { "%noarchive" }
+  let(:use_default_rules) { true }
+
+  let(:active_channel) {
+    Archivist::Channel.new(
+      Slack::Messages::Message.new(
+        id: "active-test-id",
+        name: "active-test",
+        is_member: true,
+      )
+    )
+  }
+  let(:included_active_channel) {
+    Archivist::Channel.new(
+      Slack::Messages::Message.new(
+        id: "included-active-test-id",
+        name: "included-active-test",
+      )
+    )
+  }
+  let(:stale_channel) {
+    Archivist::Channel.new(
+      Slack::Messages::Message.new(
+        id: "stale-test-id",
+        name: "stale-test",
+      )
+    )
+  }
+  let(:warned_active_channel) {
+    Archivist::Channel.new(
+      Slack::Messages::Message.new(
+        id: "warned-active-test-id",
+        name: "warned-active-test",
+      )
+    )
+  }
+  let(:warned_stale_channel) {
+    Archivist::Channel.new(
+      Slack::Messages::Message.new(
+        id: "warned-stale-test-id",
+        name: "warned-stale-test",
+      )
+    )
+  }
+  let(:general_channel) {
+    Archivist::Channel.new(
+      Slack::Messages::Message.new(
+        id: "general-test-id",
+        name: "general-test",
+        is_general: true,
+      )
+    )
+  }
+  let(:shared_channel) {
+    Archivist::Channel.new(
+      Slack::Messages::Message.new(
+        id: "shared-test-id",
+        name: "shared-test",
+        is_shared: true,
+      )
+    )
+  }
+  let(:pending_shared_channel) {
+    Archivist::Channel.new(
+      Slack::Messages::Message.new(
+        id: "pending-shared-test-id",
+        name: "pending-shared-test",
+        pending_shared: ["other-team"]
+      )
+    )
+  }
+  let(:no_archive_description_channel) {
+    Archivist::Channel.new(
+      Slack::Messages::Message.new(
+        id: "no-archive-description-test-id",
+        name: "no-archive-description-test",
+        purpose: Slack::Messages::Message.new(
+          value: "A #{no_archive_label} description!"
+        )
+      )
+    )
+  }
+  let(:no_archive_topic_channel) {
+    Archivist::Channel.new(
+      Slack::Messages::Message.new(
+        id: "no-archive-topic-test-id",
+        name: "no-archive-topic-test",
+        topic: Slack::Messages::Message.new(
+          value: "A #{no_archive_label} topic!"
+        )
+      )
+    )
+  }
+  let(:skip_channel) {
+    Archivist::Channel.new(
+      Slack::Messages::Message.new(
+        id: "skip-test-id",
+        name: "skip-test",
+      )
+    )
+  }
+
+  let(:active_conversations_history_responses) {
+    [
+      Slack::Messages::Message.new(
+        messages: [
+          Slack::Messages::Message.new(
+            subtype: "channel_join",
+            ts: Time.now.to_f.to_s
+          ),
+          Slack::Messages::Message.new(
+            subtype: "channel_leave",
+            ts: Time.now.to_f.to_s
+          ),
+          Slack::Messages::Message.new(
+            ts: Time.now.to_f.to_s
+          ),
+          Slack::Messages::Message.new(
+            ts: Time.now.to_f.to_s
+          ),
+          Slack::Messages::Message.new(
+            subtype: "bot_message",
+            ts: Time.now.to_f.to_s
+          ),
+          Slack::Messages::Message.new(
+            ts: Time.now.to_f.to_s
+          ),
+          Slack::Messages::Message.new(
+            hidden: true,
+            ts: Time.now.to_f.to_s
+          ),
+        ]
+      ),
+      Slack::Messages::Message.new(
+        messages: [
+          Slack::Messages::Message.new(
+            subtype: "bot_message",
+            ts: Time.now.to_f.to_s
+          ),
+        ]
+      ),
+    ]
+  }
+  let(:stale_conversations_history_responses) {
+    [
+      Slack::Messages::Message.new(
+        messages: [
+          Slack::Messages::Message.new(
+            subtype: "channel_join",
+            ts: Time.now.to_f.to_s
+          ),
+          Slack::Messages::Message.new(
+            subtype: "channel_leave",
+            ts: Time.now.to_f.to_s
+          ),
+          Slack::Messages::Message.new(
+            subtype: "bot_message",
+            ts: Time.now.to_f.to_s
+          ),
+          Slack::Messages::Message.new(
+            hidden: true,
+            ts: Time.now.to_f.to_s
+          ),
+        ]
+      ),
+      Slack::Messages::Message.new(
+        messages: [
+          Slack::Messages::Message.new(
+            subtype: "bot_message",
+            ts: Time.now.to_f.to_s
+          ),
+          Slack::Messages::Message.new(
+            bot_id: "testbotid",
+            ts: Time.now.to_f.to_s
+          ),
+        ]
+      ),
+    ]
+  }
+  let(:warned_active_conversations_history_responses) {
+    [
+      Slack::Messages::Message.new(
+        messages: [
+          Slack::Messages::Message.new(
+            ts: Time.now.to_f.to_s
+          ),
+          Slack::Messages::Message.new(
+            blocks: [
+              Slack::Messages::Message.new(block_id: "archivist-warn-1234"),
+            ],
+            bot_id: "testbotid",
+            ts: Time.now.to_f.to_s
+          ),
+        ]
+      ),
+    ]
+  }
+  let(:warned_stale_conversations_history_responses) {
+    [
+      Slack::Messages::Message.new(
+        messages: [
+          Slack::Messages::Message.new(
+            blocks: [
+              Slack::Messages::Message.new(block_id: "archivist-warn-1234"),
+            ],
+            bot_id: "testbotid",
+            ts: Time.now.to_f.to_s
+          ),
+        ]
+      ),
+    ]
+  }
+
+  before do
+    Archivist::Config.configure
+
+    allow(Archivist::Config).to receive(:slack_api_token) { "test-api-token" }
+    allow(Archivist::Config).to receive(:no_archive_label) { no_archive_label }
+    allow(Archivist::Config).to receive(:use_default_rules) {
+      use_default_rules
+    }
+    allow(Archivist::Config).to receive(:rules) {
+      [
+        Archivist::Rule.new("included-", days: 123),
+        Archivist::Rule.new("stale-", days: 123),
+        Archivist::Rule.new("warned-", days: 123),
+        Archivist::Rule.new("skip-", skip: true),
+      ]
+    }
+
+    Archivist::Client.configure
+
+    allow(Archivist::Client)
+      .to receive(:last_messages_in) { |channel, params, &block|
+        case channel.id
+        when stale_channel.id
+          next stale_conversations_history_responses.each(&block)
+        when warned_active_channel.id
+          next warned_active_conversations_history_responses.each(&block)
+        when warned_stale_channel.id
+          next warned_stale_conversations_history_responses.each(&block)
+        else
+          next active_conversations_history_responses.each(&block)
+        end
+      }
+
+    allow(SecureRandom).to receive(:uuid) { "1234" }
+  end
+
+  describe "#id" do
+    it "matches the wrapped channel's id" do
+      expect(active_channel.id).to eq("active-test-id")
+    end
+  end
+
+  describe "#name" do
+    it "matches the wrapped channel's name" do
+      expect(active_channel.name).to eq("active-test")
+    end
+  end
+
+  describe "#member?" do
+    it "matches the wrapped channel's member status" do
+      expect(active_channel.member?).to eq(true)
+      expect(stale_channel.member?).to eq(false)
+    end
+  end
+
+  describe "#general?" do
+    it "matches the wrapped channel's general status" do
+      expect(active_channel.general?).to eq(false)
+      expect(general_channel.general?).to eq(true)
+    end
+  end
+
+  describe "#shared?" do
+    it "matches the wrapped channel's shared status" do
+      expect(active_channel.shared?).to eq(false)
+      expect(shared_channel.shared?).to eq(true)
+      expect(pending_shared_channel.shared?).to eq(true)
+    end
+  end
+
+  describe "#monitored?" do
+    context "with default rules" do
+      let(:use_default_rules) { true }
+
+      it "returns true for channels covered by the rules" do
+        expect(active_channel.monitored?).to eq(true)
+        expect(stale_channel.monitored?).to eq(true)
+        expect(warned_active_channel.monitored?).to eq(true)
+        expect(warned_stale_channel.monitored?).to eq(true)
+      end
+
+      it "returns false for channels not covered by the rules" do
+        expect(general_channel.monitored?).to eq(false)
+        expect(shared_channel.monitored?).to eq(false)
+        expect(pending_shared_channel.monitored?).to eq(false)
+        expect(no_archive_description_channel.monitored?).to eq(false)
+        expect(no_archive_topic_channel.monitored?).to eq(false)
+        expect(skip_channel.monitored?).to eq(false)
+      end
+    end
+
+    context "without default rules" do
+      let(:use_default_rules) { false }
+
+      it "returns true for channels covered by the rules" do
+        expect(stale_channel.monitored?).to eq(true)
+        expect(warned_active_channel.monitored?).to eq(true)
+        expect(warned_stale_channel.monitored?).to eq(true)
+      end
+
+      it "returns false for channels not covered by the rules" do
+        expect(active_channel.monitored?).to eq(false)
+        expect(general_channel.monitored?).to eq(false)
+        expect(shared_channel.monitored?).to eq(false)
+        expect(pending_shared_channel.monitored?).to eq(false)
+        expect(no_archive_description_channel.monitored?).to eq(false)
+        expect(no_archive_topic_channel.monitored?).to eq(false)
+        expect(skip_channel.monitored?).to eq(false)
+      end
+    end
+  end
+
+  describe "#not_monitored?" do
+    context "with default rules" do
+      let(:use_default_rules) { true }
+
+      it "returns false for channels covered by the rules" do
+        expect(active_channel.not_monitored?).to eq(false)
+        expect(stale_channel.not_monitored?).to eq(false)
+        expect(warned_active_channel.not_monitored?).to eq(false)
+        expect(warned_stale_channel.not_monitored?).to eq(false)
+      end
+
+      it "returns true for channels not covered by the rules" do
+        expect(general_channel.not_monitored?).to eq(true)
+        expect(shared_channel.not_monitored?).to eq(true)
+        expect(pending_shared_channel.not_monitored?).to eq(true)
+        expect(no_archive_description_channel.not_monitored?).to eq(true)
+        expect(no_archive_topic_channel.not_monitored?).to eq(true)
+        expect(skip_channel.not_monitored?).to eq(true)
+      end
+    end
+
+    context "without default rules" do
+      let(:use_default_rules) { false }
+
+      it "returns false for channels covered by the rules" do
+        expect(stale_channel.not_monitored?).to eq(false)
+        expect(warned_active_channel.not_monitored?).to eq(false)
+        expect(warned_stale_channel.not_monitored?).to eq(false)
+      end
+
+      it "returns true for channels not covered by the rules" do
+        expect(active_channel.not_monitored?).to eq(true)
+        expect(general_channel.not_monitored?).to eq(true)
+        expect(shared_channel.not_monitored?).to eq(true)
+        expect(pending_shared_channel.not_monitored?).to eq(true)
+        expect(no_archive_description_channel.not_monitored?).to eq(true)
+        expect(no_archive_topic_channel.not_monitored?).to eq(true)
+        expect(skip_channel.not_monitored?).to eq(true)
+      end
+    end
+  end
+
+  describe "#warnable?" do
+    context "with default rules" do
+      let(:use_default_rules) { true }
+
+      it "returns true for stale monitored channels" do
+        expect(stale_channel.warnable?).to eq(true)
+      end
+
+      it "returns false for active monitored channels" do
+        expect(active_channel.warnable?).to eq(false)
+      end
+
+      it "returns false for recently warned stale monitored channels" do
+        expect(warned_stale_channel.warnable?).to eq(false)
+      end
+
+      it "returns false for recently warned active monitored channels" do
+        expect(warned_active_channel.warnable?).to eq(false)
+      end
+
+      it "returns false for unmonitored channels" do
+        expect(general_channel.warnable?).to eq(false)
+        expect(shared_channel.warnable?).to eq(false)
+        expect(pending_shared_channel.warnable?).to eq(false)
+        expect(no_archive_description_channel.warnable?).to eq(false)
+        expect(no_archive_topic_channel.warnable?).to eq(false)
+        expect(skip_channel.warnable?).to eq(false)
+      end
+    end
+
+    context "without default rules" do
+      let(:use_default_rules) { false }
+
+      it "returns true for stale monitored channels" do
+        expect(stale_channel.warnable?).to eq(true)
+      end
+
+      it "returns false for active monitored channels" do
+        expect(active_channel.warnable?).to eq(false)
+      end
+
+      it "returns false for recently warned stale monitored channels" do
+        expect(warned_stale_channel.warnable?).to eq(false)
+      end
+
+      it "returns false for recently warned active monitored channels" do
+        expect(warned_active_channel.warnable?).to eq(false)
+      end
+
+      it "returns false for unmonitored channels" do
+        expect(active_channel.warnable?).to eq(false)
+        expect(general_channel.warnable?).to eq(false)
+        expect(shared_channel.warnable?).to eq(false)
+        expect(pending_shared_channel.warnable?).to eq(false)
+        expect(no_archive_description_channel.warnable?).to eq(false)
+        expect(no_archive_topic_channel.warnable?).to eq(false)
+        expect(skip_channel.warnable?).to eq(false)
+      end
+    end
+  end
+
+  describe "#archivable?" do
+    context "with default rules" do
+      let(:use_default_rules) { true }
+
+      it "returns false for stale monitored channels" do
+        expect(stale_channel.archivable?).to eq(false)
+      end
+
+      it "returns false for active monitored channels" do
+        expect(active_channel.archivable?).to eq(false)
+      end
+
+      it "returns true for recently warned stale monitored channels" do
+        expect(warned_stale_channel.archivable?).to eq(true)
+      end
+
+      it "returns false for recently warned active monitored channels" do
+        expect(warned_active_channel.archivable?).to eq(false)
+      end
+
+      it "returns false for unmonitored channels" do
+        expect(general_channel.archivable?).to eq(false)
+        expect(shared_channel.archivable?).to eq(false)
+        expect(pending_shared_channel.archivable?).to eq(false)
+        expect(no_archive_description_channel.archivable?).to eq(false)
+        expect(no_archive_topic_channel.archivable?).to eq(false)
+        expect(skip_channel.archivable?).to eq(false)
+      end
+    end
+
+    context "without default rules" do
+      let(:use_default_rules) { false }
+
+      it "returns false for stale monitored channels" do
+        expect(stale_channel.archivable?).to eq(false)
+      end
+
+      it "returns false for active monitored channels" do
+        expect(active_channel.archivable?).to eq(false)
+      end
+
+      it "returns true for recently warned stale monitored channels" do
+        expect(warned_stale_channel.archivable?).to eq(true)
+      end
+
+      it "returns false for recently warned active monitored channels" do
+        expect(warned_active_channel.archivable?).to eq(false)
+      end
+
+      it "returns false for unmonitored channels" do
+        expect(active_channel.archivable?).to eq(false)
+        expect(general_channel.archivable?).to eq(false)
+        expect(shared_channel.archivable?).to eq(false)
+        expect(pending_shared_channel.archivable?).to eq(false)
+        expect(no_archive_description_channel.archivable?).to eq(false)
+        expect(no_archive_topic_channel.archivable?).to eq(false)
+        expect(skip_channel.archivable?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,9 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 
 require "logger"
 require "slack-ruby-client"
+require "timecop"
 
 require "archivist"
-require "timecop"
 
 ENV["ARCHIVIST_SLACK_API_TOKEN"] = "testtoken"
 


### PR DESCRIPTION
We pull all of the channel methods out of the job class and into a wrapper class.

We also unmemoize the tasks in the archive channels job to try and be more reliable about running with the correct state.