### PR TITLE
Require active_support explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "activesupport"
 gem "dotenv"
 gem "memoist"
 gem "slack-ruby-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   byebug
   dotenv
   memoist

--- a/lib/archivist.rb
+++ b/lib/archivist.rb
@@ -1,3 +1,5 @@
+require "active_support"
+require "active_support/core_ext"
 require "logger"
 require "memoist"
 require "securerandom"


### PR DESCRIPTION
Currently, the project uses some functionality provided by `active_support`, but doesn’t require this gem explicitly. The gem is included as a dependency of another gem, `slack-ruby-client`.

Future releases of `slack-ruby-client` (ref https://github.com/dxw/archivist/pull/40 ) eliminate the `active_support` dependency, which causes archivist functionality to break.

In preparation for updating `slack-ruby-client`, require `active_support` explicitly.