### PR TITLE
Pass Unix timestamps to the Slack API

### DIFF
--- a/lib/archivist/client.rb
+++ b/lib/archivist/client.rb
@@ -57,8 +57,8 @@ module Archivist
           channel: channel.id,
           limit: limit,
           # Providing `latest` means the history is fetched most recent first.
-          latest: min_days_ago.nil? ? Time.now : (Date.today - min_days_ago),
-          oldest: max_days_ago && Date.today - max_days_ago,
+          latest: min_days_ago.nil? ? Time.now.to_i : (Date.today - min_days_ago).to_time.to_i,
+          oldest: max_days_ago && (Date.today - max_days_ago).to_time.to_i,
 
           # Client configuration
           sleep_interval: 1,

--- a/spec/archivist/archive_channels_spec.rb
+++ b/spec/archivist/archive_channels_spec.rb
@@ -314,8 +314,8 @@ describe Archivist::ArchiveChannels do
           .with(
             channel: active_channel.id,
             limit: nil,
-            latest: Time.now,
-            oldest: Date.today - 30,
+            latest: Time.now.to_i,
+            oldest: (Date.today - 30).to_time.to_i,
             sleep_interval: 1
           )
 
@@ -330,8 +330,8 @@ describe Archivist::ArchiveChannels do
           .with(
             channel: stale_channel.id,
             limit: nil,
-            latest: Time.now,
-            oldest: Date.today - rules[0].days,
+            latest: Time.now.to_i,
+            oldest: (Date.today - rules[0].days).to_time.to_i,
             sleep_interval: 1
           )
 

--- a/spec/archivist/client_spec.rb
+++ b/spec/archivist/client_spec.rb
@@ -99,8 +99,8 @@ describe Archivist::Client do
         .with(
           channel: channel.id,
           limit: 123,
-          latest: Date.today - 12,
-          oldest: Date.today - 23,
+          latest: (Date.today - 12).to_time.to_i,
+          oldest: (Date.today - 23).to_time.to_i,
           sleep_interval: 1
         )
 


### PR DESCRIPTION
The API doesn't know how to interpret `Date`s, but it silently fails, treating them as `nil`. This meant that only new channels would be archivable because the latest message search would find all messages, not the ones since the max age.