### PR TITLE
Use ruby/setup-ruby action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: "2.7.x"
+      - uses: ruby/setup-ruby@v1
 
       - name: Install test dependencies
         run: bundle install --frozen --jobs 4 --retry 3 --without development


### PR DESCRIPTION
The previous one has been deprecated. The `ruby/setup-ruby` action will use the Ruby version defined in the .ruby-version file. Hopefully, this will fix the CI builds.